### PR TITLE
Bump Play to 2.6.5.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Key features:
 * Converts from Java `Callable<CompletionStage<T>>` or Scala `() => Future[T]` to ParSeq `Task`, which allows existing code using Play native APIs to be integrated with ParSeq Tasks.
 * Supports [ParSeq Trace](https://github.com/linkedin/parseq/wiki/Tracing).
 * Provides both Scala and Java API.
-* Requires Play 2.5 (Dependency Injection).
+* Requires Play 2.6.
 
 ## Getting Play-ParSeq
 
@@ -95,7 +95,7 @@ Key features:
 
     ```scala
     ...
-    class Sample @Inject()(playParSeq: PlayParSeq) extends Controller {
+    class Sample @Inject()(playParSeq: PlayParSeq, cc: ControllerComponents) extends AbstractController(cc) {
     ...
     ```
 
@@ -135,7 +135,7 @@ Key features:
 
     ```scala
     ...
-    class Sample @Inject()(playParSeq: PlayParSeq, parSeqTraceAction: ParSeqTraceAction) extends Controller {
+    class Sample @Inject()(playParSeq: PlayParSeq, parSeqTraceAction: ParSeqTraceAction, cc: ControllerComponents) extends AbstractController(cc) {
     ...
     ```
 
@@ -157,7 +157,7 @@ Please see `/sample`.
 
 ### Why is there no ParSeq Trace Viewer even though I've added `parseq-trace=true` to my query?
 
-**A:** Please first make sure you annotated your Action with `@With(ParSeqTraceAction.class)` in Java, or you used `parSeqTraceAction.async` for your Action in Scala. Then check whether you meet all `ParSeqTraceSensor` requirements of showing ParSeq Trace. And also don't forget using `runTask` in your Action.
+**A:** Please first make sure you annotated your Action with `@With(ParSeqTraceAction.class)` in Java, or you used `parSeqTraceAction.async` for your Action in Scala. Then check whether you meet all `ParSeqTraceSensor` requirements of showing ParSeq Trace. And also don't forget using `runTask` in your Action. Please also note that ParSeq Trace Viewer will be blocked by strict Content Security Policy rules because of some inline scripts and styles.
 
 ### How can I use my own module settings?
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,10 @@
 import scala.language.postfixOps
 
-val playParSeqVersion = "0.7.0"
+val playParSeqVersion = "0.8.0"
 
 val playParSeqScalaVersion = "2.11.11"
 
-val playParSeqCrossScalaVersions = Seq("2.11.11")
+val playParSeqCrossScalaVersions = Seq("2.11.11", "2.12.4")
 
 val parSeqVersion = "2.6.22"
 
@@ -110,6 +110,7 @@ lazy val `play-parseq-sample` =
       name := """play-parseq-sample""",
       commonSettings,
       libraryDependencies ++= Seq(
+        guice,
         javaWs,
         ws,
         "com.linkedin.parseq" % "parseq-http-client" % parSeqVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.18")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.5")

--- a/sample/app/controllers/Application.scala
+++ b/sample/app/controllers/Application.scala
@@ -11,15 +11,17 @@
  */
 package controllers
 
-import play.api.mvc.{Action, Controller}
+import javax.inject.Inject
+import play.api.mvc.{AbstractController, ControllerComponents}
 
 
 /**
  * The class Application is a Controller to show index page.
  *
+ * @param controllerComponents The injected Controller component.
  * @author Yinan Ding (yding@linkedin.com)
  */
-class Application extends Controller {
+class Application @Inject()(controllerComponents: ControllerComponents) extends AbstractController(controllerComponents) {
 
   /**
    * The method index returns the index page.

--- a/sample/app/controllers/s/CoreOnlySample.scala
+++ b/sample/app/controllers/s/CoreOnlySample.scala
@@ -13,7 +13,7 @@ package controllers.s
 
 import com.linkedin.playparseq.s.PlayParSeq
 import javax.inject.Inject
-import play.api.mvc.{Action, AnyContent, Controller}
+import play.api.mvc._
 import scala.concurrent.{ExecutionContext, Future}
 
 
@@ -22,10 +22,11 @@ import scala.concurrent.{ExecutionContext, Future}
  * execution of ParSeq Task by substring jobs without enabling the ParSeq Trace feature.
  *
  * @param playParSeq The injected [[PlayParSeq]] component
+ * @param controllerComponents The injected Controller component
  * @param executionContext The injected [[ExecutionContext]] component
  * @author Yinan Ding (yding@linkedin.com)
  */
-class CoreOnlySample @Inject()(playParSeq: PlayParSeq)(implicit executionContext: ExecutionContext) extends Controller {
+class CoreOnlySample @Inject()(playParSeq: PlayParSeq, controllerComponents: ControllerComponents)(implicit executionContext: ExecutionContext) extends AbstractController(controllerComponents) {
 
   /**
    * The field DefaultFailure is the default failure output.

--- a/sample/app/controllers/s/MultipleTasksSample.scala
+++ b/sample/app/controllers/s/MultipleTasksSample.scala
@@ -19,7 +19,7 @@ import com.linkedin.playparseq.trace.s.ParSeqTraceAction
 import com.ning.http.client.Response
 import javax.inject.Inject
 import play.api.libs.ws.WSClient
-import play.api.mvc.{Action, AnyContent, Controller}
+import play.api.mvc._
 import scala.concurrent.{ExecutionContext, Future}
 
 
@@ -30,10 +30,11 @@ import scala.concurrent.{ExecutionContext, Future}
  * @param ws The injected WSClient component
  * @param playParSeq The injected [[PlayParSeq]] component
  * @param parSeqTraceAction The injected [[ParSeqTraceAction]] component
+ * @param controllerComponents The injected Controller component
  * @param executionContext The injected [[ExecutionContext]] component
  * @author Yinan Ding (yding@linkedin.com)
  */
-class MultipleTasksSample @Inject()(ws: WSClient, playParSeq: PlayParSeq, parSeqTraceAction: ParSeqTraceAction)(implicit executionContext: ExecutionContext) extends Controller {
+class MultipleTasksSample @Inject()(ws: WSClient, playParSeq: PlayParSeq, parSeqTraceAction: ParSeqTraceAction, controllerComponents: ControllerComponents)(implicit executionContext: ExecutionContext) extends AbstractController(controllerComponents) {
 
   /**
    * The method demo runs two independent Tasks, and is able to show the ParSeq Trace if the request has

--- a/sample/app/controllers/s/SingleTaskSample.scala
+++ b/sample/app/controllers/s/SingleTaskSample.scala
@@ -14,9 +14,9 @@ package controllers.s
 import com.linkedin.parseq.Task
 import com.linkedin.playparseq.s.PlayParSeq
 import com.linkedin.playparseq.s.PlayParSeqImplicits._
-import javax.inject.Inject
 import com.linkedin.playparseq.trace.s.ParSeqTraceAction
-import play.api.mvc.{Action, AnyContent, Controller}
+import javax.inject.Inject
+import play.api.mvc._
 import scala.concurrent.{ExecutionContext, Future}
 
 
@@ -26,10 +26,11 @@ import scala.concurrent.{ExecutionContext, Future}
  *
  * @param playParSeq The injected [[PlayParSeq]] component
  * @param parSeqTraceAction The injected [[ParSeqTraceAction]] component
+ * @param controllerComponents The injected Controller component
  * @param executionContext The injected [[ExecutionContext]] component
  * @author Yinan Ding (yding@linkedin.com)
  */
-class SingleTaskSample @Inject()(playParSeq: PlayParSeq, parSeqTraceAction: ParSeqTraceAction)(implicit executionContext: ExecutionContext) extends Controller {
+class SingleTaskSample @Inject()(playParSeq: PlayParSeq, parSeqTraceAction: ParSeqTraceAction, controllerComponents: ControllerComponents)(implicit executionContext: ExecutionContext) extends AbstractController(controllerComponents) {
 
   /**
    * The method demo runs one Task, and is able to show the ParSeq Trace if the request has `parseq-trace=true`.

--- a/sample/conf/application.conf
+++ b/sample/conf/application.conf
@@ -8,6 +8,9 @@ play.http.context = "/sample"
 # ~~~~~
 play.i18n.langs = ["en"]
 
+# Disable Content Security Policy to allow ParSeq Trace UI working properly
+play.filters.headers.contentSecurityPolicy=null
+
 # Module Register
 # ~~~~~
 # Preset settings for Java core. Replace if you want to use your own.

--- a/sample/test/controllers/j/CoreOnlySampleTest.java
+++ b/sample/test/controllers/j/CoreOnlySampleTest.java
@@ -49,7 +49,7 @@ public class CoreOnlySampleTest extends WithApplication {
    */
   @Test
   public void canGetInput() {
-    Result result = route(routes.CoreOnlySample.input());
+    Result result = route(app, routes.CoreOnlySample.input());
     // Assert the status and the content
     assertEquals(OK, result.status());
     assertEquals("text/html", result.contentType().orElse(""));
@@ -61,7 +61,7 @@ public class CoreOnlySampleTest extends WithApplication {
    */
   @Test
   public void canGetDemo() {
-    Result result = route(routes.CoreOnlySample.demo(TEST_TEXT, TEST_START));
+    Result result = route(app, routes.CoreOnlySample.demo(TEST_TEXT, TEST_START));
     // Assert the status and the content
     assertEquals(OK, result.status());
     assertEquals("text/plain", result.contentType().orElse(""));
@@ -73,7 +73,7 @@ public class CoreOnlySampleTest extends WithApplication {
    */
   @Test
   public void canGetDemoWithFailure() {
-    Result result = route(routes.CoreOnlySample.demo(TEST_TEXT, TEST_START_FAIL));
+    Result result = route(app, routes.CoreOnlySample.demo(TEST_TEXT, TEST_START_FAIL));
     // Assert the status and the content
     assertEquals(OK, result.status());
     assertEquals("text/plain", result.contentType().orElse(""));

--- a/sample/test/controllers/j/MultipleTasksSampleTest.java
+++ b/sample/test/controllers/j/MultipleTasksSampleTest.java
@@ -34,7 +34,7 @@ public class MultipleTasksSampleTest extends WithApplication {
    */
   @Test
   public void canGetDemo() {
-    Result result = route(routes.MultipleTasksSample.demo());
+    Result result = route(app, routes.MultipleTasksSample.demo());
     // Assert the status and the content
     assertEquals(OK, result.status());
     assertEquals("text/plain", result.contentType().orElse(""));

--- a/sample/test/controllers/j/SingleTaskSampleTest.java
+++ b/sample/test/controllers/j/SingleTaskSampleTest.java
@@ -34,7 +34,7 @@ public class SingleTaskSampleTest extends WithApplication {
    */
   @Test
   public void canGetDemo() {
-    Result result = route(routes.SingleTaskSample.demo());
+    Result result = route(app, routes.SingleTaskSample.demo());
     // Assert the status and the content
     assertEquals(OK, result.status());
     assertEquals("text/plain", result.contentType().orElse(""));

--- a/sample/test/controllers/s/CoreOnlySampleSpec.scala
+++ b/sample/test/controllers/s/CoreOnlySampleSpec.scala
@@ -58,7 +58,7 @@ class CoreOnlySampleSpec extends PlaySpecification {
       // Assert the status and the content
       status(result) must equalTo(OK)
       contentType(result) must beSome("text/plain")
-      contentAsString(result) must equalTo(new CoreOnlySample(null)(null).DefaultFailure)
+      contentAsString(result) must equalTo(new CoreOnlySample(null, null)(null).DefaultFailure)
     }
   }
 

--- a/src/core/java/app/com/linkedin/playparseq/j/stores/ParSeqTaskStore.java
+++ b/src/core/java/app/com/linkedin/playparseq/j/stores/ParSeqTaskStore.java
@@ -18,8 +18,9 @@ import play.mvc.Http;
 
 /**
  * The interface ParSeqTaskStore defines putting ParSeq Task into store and getting Tasks out of store.
- * During a request, the ParSeqTaskStore will store all ParSeq Tasks when they run. The ParSeqTaskStore will retrieve
- * all the Tasks only when it needs to generate the ParSeq Trace of the current request.
+ * During a request, all ParSeq Tasks will be stored in the ParSeqTaskStore when they run, and will be retrieved when it
+ * needs to generate the ParSeq Trace of the current request. The put/get APIs can only be properly used after the API
+ * initialize is called for setting up the store.
  *
  * @author Yinan Ding (yding@linkedin.com)
  */
@@ -34,11 +35,19 @@ public interface ParSeqTaskStore {
   void put(final Http.Context context, final Task<?> task);
 
   /**
-   * The method get gets all Tasks from one request out of store as a Set.
+   * The method get gets all Tasks from one request out of store as an unmodifiable Set.
    *
    * @param context The HTTP Context
    * @return A set of Tasks
    */
   Set<Task<?>> get(final Http.Context context);
+
+  /**
+   * The method initialize sets up the store properly for put/get APIs.
+   *
+   * @param context The origin HTTP Context
+   * @return The HTTP Context with store set up properly
+   */
+  Http.Context initialize(final Http.Context context);
 
 }

--- a/src/core/scala/app/com/linkedin/playparseq/utils/EngineProvider.scala
+++ b/src/core/scala/app/com/linkedin/playparseq/utils/EngineProvider.scala
@@ -71,7 +71,7 @@ class EngineProvider @Inject()(applicationLifecycle: ApplicationLifecycle, confi
    *
    * @return The number of threads
    */
-  private[this] def getNumThreads: Int = configuration.getInt("parseq.engine.numThreads").getOrElse(Runtime.getRuntime.availableProcessors + 1)
+  private[this] def getNumThreads: Int = configuration.getOptional[Int]("parseq.engine.numThreads").getOrElse(Runtime.getRuntime.availableProcessors + 1)
 
   /**
    * The method getTerminationWaitSeconds gets the maximum time to wait for Engine's termination in the unit of seconds.
@@ -79,6 +79,6 @@ class EngineProvider @Inject()(applicationLifecycle: ApplicationLifecycle, confi
    *
    * @return The time to wait in seconds
    */
-  private[this] def getTerminationWaitSeconds: Int = configuration.getInt("parseq.engine.terminationWaitSeconds").getOrElse(1)
+  private[this] def getTerminationWaitSeconds: Int = configuration.getOptional[Int]("parseq.engine.terminationWaitSeconds").getOrElse(1)
 
 }

--- a/src/core/scala/test/com/linkedin/playparseq/s/PlayParSeqImplSpec.scala
+++ b/src/core/scala/test/com/linkedin/playparseq/s/PlayParSeqImplSpec.scala
@@ -17,10 +17,10 @@ import com.linkedin.playparseq.s.stores.ParSeqTaskStore
 import java.util.concurrent.{Executors, ExecutorService, ScheduledExecutorService, TimeUnit}
 import org.specs2.mock.Mockito
 import org.specs2.specification.BeforeAfterEach
-import play.api.libs.concurrent.Execution
-import play.api.libs.concurrent.Execution.Implicits._
 import play.api.mvc.RequestHeader
 import play.api.test.PlaySpecification
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContext.Implicits._
 import scala.concurrent.Future
 
 
@@ -65,7 +65,7 @@ class PlayParSeqImplSpec extends PlaySpecification with BeforeAfterEach with Moc
     taskScheduler = Executors.newFixedThreadPool(Runtime.getRuntime.availableProcessors + 1)
     timerScheduler = Executors.newSingleThreadScheduledExecutor
     engine = new EngineBuilder().setTaskExecutor(taskScheduler).setTimerScheduler(timerScheduler).build
-    playParSeqImpl = new PlayParSeqImpl(engine, mock[ParSeqTaskStore])(Execution.defaultContext)
+    playParSeqImpl = new PlayParSeqImpl(engine, mock[ParSeqTaskStore])(ExecutionContext.global)
   }
 
   /**

--- a/src/trace/java/app/com/linkedin/playparseq/trace/j/ParSeqTraceAction.java
+++ b/src/trace/java/app/com/linkedin/playparseq/trace/j/ParSeqTraceAction.java
@@ -22,8 +22,11 @@ import play.mvc.Result;
 
 
 /**
- * The class ParSeqTraceAction is an Action which composes with {@link ParSeqTraceBuilder} to hand origin Result off in
- * order to determine whether to show ParSeq Trace data or the origin Result, if so generate the ParSeq Trace Result.
+ * The class ParSeqTraceAction is an Action composition which sets up a normal HTTP Context with {@link ParSeqTaskStore}
+ * in order to put ParSeq Task into store for retrieving all Tasks within the scope of one request when building ParSeq
+ * Trace.
+ * And it also composes with {@link ParSeqTraceBuilder} to hand origin Result off in order to determine whether to show
+ * ParSeq Trace data or the origin Result, if so generate the ParSeq Trace Result.
  *
  * @author Yinan Ding (yding@linkedin.com)
  */
@@ -69,14 +72,16 @@ public class ParSeqTraceAction extends Simple {
   }
 
   /**
-   * The method call composes with {@link ParSeqTraceBuilder} to build ParSeq Trace for the request.
+   * The method call sets up a normal HTTP Context with {@link ParSeqTaskStore} and composes with
+   * {@link ParSeqTraceBuilder} to build ParSeq Trace for the request.
    *
    * @param context The HTTP Context
    * @return The CompletionStage of Result
    */
   @Override
   public CompletionStage<Result> call(final Http.Context context) {
-    return _parSeqTraceBuilder.build(context, delegate.call(context), _parSeqTaskStore, _parSeqTraceSensor,
+    Http.Context newContext = _parSeqTaskStore.initialize(context);
+    return _parSeqTraceBuilder.build(newContext, delegate.call(newContext), _parSeqTaskStore, _parSeqTraceSensor,
         _parSeqTraceRenderer);
   }
 

--- a/src/trace/java/app/com/linkedin/playparseq/trace/j/renderers/ParSeqTraceRendererImpl.java
+++ b/src/trace/java/app/com/linkedin/playparseq/trace/j/renderers/ParSeqTraceRendererImpl.java
@@ -79,7 +79,7 @@ public class ParSeqTraceRendererImpl extends ParSeqTraceBaseVisualizer implement
       });
       // Generate Result of ParSeq Trace
       return Optional.ofNullable(
-          showTrace(new Trace(traceMap, relationships), _environment.underlying(), _httpConfiguration))
+          showTrace(new Trace(traceMap, relationships), _environment.asScala(), _httpConfiguration))
           .map(s -> Results.ok(s).as("text/html")).orElse(Results.internalServerError("Can't show Trace."));
     });
   }

--- a/src/trace/scala/app/com/linkedin/playparseq/trace/controllers/ParSeqTraceViewer.scala
+++ b/src/trace/scala/app/com/linkedin/playparseq/trace/controllers/ParSeqTraceViewer.scala
@@ -14,6 +14,7 @@ package com.linkedin.playparseq.trace.controllers
 import com.linkedin.parseq.{Engine, GraphvizEngine, HttpResponse, Task}
 import com.linkedin.playparseq.s.PlayParSeqImplicits._
 import com.linkedin.playparseq.utils.PlayParSeqHelper
+import controllers.Assets
 import java.io.ByteArrayInputStream
 import java.nio.file.{Files, Path}
 import javax.inject.{Inject, Singleton}
@@ -22,7 +23,7 @@ import org.apache.commons.io.FileUtils
 import play.api.Configuration
 import play.api.Logger
 import play.api.inject.ApplicationLifecycle
-import play.api.mvc.{Action, AnyContent, Controller, Result}
+import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents, Result}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.sys.process
 import scala.util.{Failure, Success, Try}
@@ -35,11 +36,13 @@ import scala.util.{Failure, Success, Try}
  * @param engine The injected ParSeq Engine component
  * @param applicationLifecycle The injected ApplicationLifeCycle component
  * @param configuration The injected Configuration component
+ * @param assets The injected Assets Controller
+ * @param controllerComponents The injected Controller component
  * @param executionContext The injected [[ExecutionContext]] component
  * @author Yinan Ding (yding@linkedin.com)
  */
 @Singleton
-class ParSeqTraceViewer @Inject()(engine: Engine, applicationLifecycle: ApplicationLifecycle, configuration: Configuration)(implicit executionContext: ExecutionContext) extends PlayParSeqHelper with Controller {
+class ParSeqTraceViewer @Inject()(engine: Engine, applicationLifecycle: ApplicationLifecycle, configuration: Configuration, assets: Assets, val controllerComponents: ControllerComponents)(implicit executionContext: ExecutionContext) extends PlayParSeqHelper with BaseController {
 
   /**
    * A happy logger.
@@ -86,7 +89,7 @@ class ParSeqTraceViewer @Inject()(engine: Engine, applicationLifecycle: Applicat
       }
     } else {
       // Resource file
-      controllers.Assets.at("/tracevis", file)
+      assets.at("/tracevis", file)
     }
   }
 
@@ -120,7 +123,7 @@ class ParSeqTraceViewer @Inject()(engine: Engine, applicationLifecycle: Applicat
    *
    * @return The file path
    */
-  private[this] def getDotLocation: String = configuration.getString("parseq.trace.docLocation").getOrElse(Try {
+  private[this] def getDotLocation: String = configuration.getOptional[String]("parseq.trace.docLocation").getOrElse(Try {
     System.getProperty("os.name").toLowerCase match {
       case u if u.indexOf("mac") >= 0 || u.indexOf("nix") >= 0 || u.indexOf("nux") >= 0 || u.indexOf("aix") >= 0 => process.stringToProcess("which dot").!!.trim
       case w if w.indexOf("win") >= 0 => process.stringToProcess("where dot").!!.trim
@@ -137,7 +140,7 @@ class ParSeqTraceViewer @Inject()(engine: Engine, applicationLifecycle: Applicat
    *
    * @return The number of cache
    */
-  private[this] def getCacheSize: Int = configuration.getInt("parseq.trace.cacheSize").getOrElse(1024)
+  private[this] def getCacheSize: Int = configuration.getOptional[Int]("parseq.trace.cacheSize").getOrElse(1024)
 
   /**
    * The method getTimeoutSeconds gets the timeout of the GraphvizEngine execution in the unit of milliseconds from conf
@@ -145,7 +148,7 @@ class ParSeqTraceViewer @Inject()(engine: Engine, applicationLifecycle: Applicat
    *
    * @return The timeout in milliseconds
    */
-  private[this] def getTimeoutMilliseconds: Long = configuration.getLong("parseq.trace.timeoutMilliseconds").getOrElse(5000)
+  private[this] def getTimeoutMilliseconds: Long = configuration.getOptional[Long]("parseq.trace.timeoutMilliseconds").getOrElse(5000)
 
   /**
    * The method getParallelLevel gets the maximum of the GraphvizEngine's parallel level from conf file, otherwise it
@@ -153,7 +156,7 @@ class ParSeqTraceViewer @Inject()(engine: Engine, applicationLifecycle: Applicat
    *
    * @return The parallel level
    */
-  private[this] def getParallelLevel: Int = configuration.getInt("parseq.trace.parallelLevel").getOrElse(Runtime.getRuntime.availableProcessors)
+  private[this] def getParallelLevel: Int = configuration.getOptional[Int]("parseq.trace.parallelLevel").getOrElse(Runtime.getRuntime.availableProcessors)
 
   /**
    * The method getDelayMilliseconds gets the delay time between different executions of the GraphvizEngine in the unit
@@ -161,7 +164,7 @@ class ParSeqTraceViewer @Inject()(engine: Engine, applicationLifecycle: Applicat
    *
    * @return The delay time in milliseconds
    */
-  private[this] def getDelayMilliseconds: Long = configuration.getLong("parseq.trace.delayMilliseconds").getOrElse(5)
+  private[this] def getDelayMilliseconds: Long = configuration.getOptional[Long]("parseq.trace.delayMilliseconds").getOrElse(5)
 
   /**
    * The method getProcessQueueSize gets the size of the GraphvizEngine's process queue from conf file, otherwise it
@@ -169,6 +172,6 @@ class ParSeqTraceViewer @Inject()(engine: Engine, applicationLifecycle: Applicat
    *
    * @return The size of process queue
    */
-  private[this] def getProcessQueueSize: Int = configuration.getInt("parseq.trace.processQueueSize").getOrElse(1000)
+  private[this] def getProcessQueueSize: Int = configuration.getOptional[Int]("parseq.trace.processQueueSize").getOrElse(1000)
 
 }

--- a/src/trace/scala/app/com/linkedin/playparseq/trace/s/renderers/ParSeqTraceRenderer.scala
+++ b/src/trace/scala/app/com/linkedin/playparseq/trace/s/renderers/ParSeqTraceRenderer.scala
@@ -19,7 +19,6 @@ import play.api.Environment
 import play.api.http.HttpConfiguration
 import play.api.mvc.{RequestHeader, Result, Results}
 import scala.collection.JavaConverters._
-import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future}
 
 
@@ -59,7 +58,7 @@ class ParSeqTraceRendererImpl @Inject()(environment: Environment, httpConfigurat
    */
   override def render(parSeqTaskStore: ParSeqTaskStore)(implicit requestHeader: RequestHeader): Future[Result] =
     Future {
-      val traces: mutable.Set[Trace] = parSeqTaskStore.get.map(_.getTrace)
+      val traces: Set[Trace] = parSeqTaskStore.get.map(_.getTrace)
       val traceMap: Map[java.lang.Long, ShallowTrace] = traces.foldLeft(Map[java.lang.Long, ShallowTrace]())(_ ++ _.getTraceMap.asScala)
       val relationships: Set[TraceRelationship] = traces.foldLeft(Set[TraceRelationship]())(_ ++ _.getRelationships.asScala)
       // Generate Result of ParSeq Trace

--- a/src/trace/scala/conf/com.linkedin.playparseq.trace.routes
+++ b/src/trace/scala/conf/com.linkedin.playparseq.trace.routes
@@ -6,4 +6,5 @@
 GET         /tracevis/*file        com.linkedin.playparseq.trace.controllers.ParSeqTraceViewer.at(file)
 
 # Graphviz generation
++ nocsrf
 POST        /tracevis/dot          com.linkedin.playparseq.trace.controllers.ParSeqTraceViewer.dot

--- a/src/trace/scala/test/com/linkedin/playparseq/trace/s/ParSeqTraceBuilderImplSpec.scala
+++ b/src/trace/scala/test/com/linkedin/playparseq/trace/s/ParSeqTraceBuilderImplSpec.scala
@@ -17,10 +17,9 @@ import com.linkedin.playparseq.s.stores.ParSeqTaskStore
 import com.linkedin.playparseq.trace.s.sensors.ParSeqTraceSensor
 import com.linkedin.playparseq.trace.s.renderers.ParSeqTraceRenderer
 import org.specs2.mock.Mockito
-import play.api.libs.concurrent.Execution
 import play.api.mvc.{RequestHeader, Result, Results}
 import play.api.test.PlaySpecification
-import scala.collection.mutable
+import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 
@@ -36,7 +35,7 @@ class ParSeqTraceBuilderImplSpec extends PlaySpecification with Mockito {
       val render: String = "render"
       // Mock ParSeqTaskStore
       val mockStore: ParSeqTaskStore = mock[ParSeqTaskStore]
-      mockStore.get(any) returns mutable.Set.empty
+      mockStore.get(any) returns Set.empty
       // Mock ParSeqTraceSensor
       val mockTraceSensor: ParSeqTraceSensor = mock[ParSeqTraceSensor]
       mockTraceSensor.isEnabled(any)(any) returns true
@@ -47,7 +46,7 @@ class ParSeqTraceBuilderImplSpec extends PlaySpecification with Mockito {
       val mockMaterializer: Materializer = mock[Materializer]
       mockMaterializer.materialize[Future[Done]](any) returns Future.successful(Done)
       // Build ParSeq Trace
-      val playParSeqTraceImpl: ParSeqTraceBuilderImpl = new ParSeqTraceBuilderImpl()(mockMaterializer, Execution.defaultContext)
+      val playParSeqTraceImpl: ParSeqTraceBuilderImpl = new ParSeqTraceBuilderImpl()(mockMaterializer, ExecutionContext.global)
       val result: Future[Result] = playParSeqTraceImpl.build(Future.successful(Results.NotFound("origin")), mockStore, mockTraceSensor, mockTraceRenderer)(mock[RequestHeader])
       // Assert the status and the content
       status(result) must equalTo(OK)
@@ -61,7 +60,7 @@ class ParSeqTraceBuilderImplSpec extends PlaySpecification with Mockito {
       val origin: String = "origin"
       // Mock ParSeqTaskStore
       val mockStore: ParSeqTaskStore = mock[ParSeqTaskStore]
-      mockStore.get(any) returns mutable.Set.empty
+      mockStore.get(any) returns Set.empty
       // Mock ParSeqTraceSensor
       val mockTraceSensor: ParSeqTraceSensor = mock[ParSeqTraceSensor]
       mockTraceSensor.isEnabled(any)(any) returns false
@@ -72,7 +71,7 @@ class ParSeqTraceBuilderImplSpec extends PlaySpecification with Mockito {
       val mockMaterializier: Materializer = mock[Materializer]
       mockMaterializier.materialize[Future[Done]](any) returns Future.successful(Done)
       // Build ParSeq Trace
-      val playParSeqTraceImpl: ParSeqTraceBuilderImpl = new ParSeqTraceBuilderImpl()(mockMaterializier, Execution.defaultContext)
+      val playParSeqTraceImpl: ParSeqTraceBuilderImpl = new ParSeqTraceBuilderImpl()(mockMaterializier, ExecutionContext.global)
       val result: Future[Result] = playParSeqTraceImpl.build(Future.successful(Results.NotFound("origin")), mockStore, mockTraceSensor, mockTraceRenderer)(mock[RequestHeader])
       // Assert the status and the content
       status(result) must equalTo(NOT_FOUND)


### PR DESCRIPTION
- Bump Play to 2.6.5.
- Replace `ContextRequest` with the request's attributes in `ParSeqTaskStore` for Scala.
- Replace the HTTP Context's args with the requets's attributes in `ParSeqTaskStore` for Java.
- Add an API `initialize` in `ParSeqTaskStore` and called by `ParSeqTraceAction` for setting up the request properly for put/get APIs.
- Disable CSRF for `dot` route.
- Disable CSP for the sample project. The Trace Viewer does not work properly with strict CSP rules.