### PR TITLE
Enable releases from CI to the test repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,4 @@ branches:
 
 #Build and perform release (if needed)
 script:
-   - ./gradlew build -s
-# Once we complete the setup:
-#  - ./gradlew build -s && ./gradlew ciPerformRelease
+  - ./gradlew build -s && ./gradlew ciPerformRelease

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -6,18 +6,6 @@ shipkit {
 
 ext.releaseSpec = fileTree("dist")
 
-task showReleaseSpec {
-    description = "Shows what files will be uploaded to Bintray. Useful for debugging."
-    doLast {
-        if (releaseSpec.empty) {
-            println "Directory 'dist' is empty. Did you run the build?"
-        } else {
-            println "Following files will be released to Bintray:"
-            releaseSpec.each { println relativePath(it) }
-        }
-    }
-}
-
 plugins.withId("org.shipkit.bintray") {
    //Bintray configuration is handled by JFrog Bintray Gradle Plugin
    //For reference see the official documentation: https://github.com/bintray/gradle-bintray-plugin


### PR DESCRIPTION
1. Removed unnecessary task. One can just inspect the "dist" dir. Previously it was useful because we had the "dist" filtering logic implemented in Gradle build script. Now it has been pushed down to SBT.
2. Enable release from CI. We're ready. If this PR is merged we will release to the 'test-repo' :D This way we can test if everything works. If it does, we should clear the last TODO and change the repo to 'maven'.

Tested by running "./gradlew testRelease":

```
~/shipkit/play-parseq$ ./gradlew testRelease

> Configure project : 
  Building version '0.8.1' (value loaded from 'version.properties' file).

> Task :testRelease 
  Performing release in dry run, with cleanup:
    ./gradlew releaseNeeded performRelease releaseCleanUp -PdryRun
[releaseNeeded] Starting a Gradle Daemon, 1 busy Daemon could not be reused, use --status for details
[releaseNeeded]   Building version '0.8.1' (value loaded from 'version.properties' file).
[releaseNeeded] :identifyGitBranch
[releaseNeeded]   Executing:
[releaseNeeded]     git rev-parse --abbrev-ref HEAD
[releaseNeeded]   Identified current branch: master
[releaseNeeded] :releaseNeeded
[releaseNeeded]   Commit message to inspect for keywords '[ci skip-release]' and '[ci skip-compare-publications]': <unknown commit message>
[releaseNeeded]   Current branch 'master' matches 'master|release/.+': true
[releaseNeeded] 
[releaseNeeded]   Publication comparison was skipped (no comparison result files found).
[releaseNeeded] 
[releaseNeeded] Release is considered _not_ needed when:
[releaseNeeded]  - 'SKIP_RELEASE' environment variable is present (currently: false)
[releaseNeeded]  - commit message contains '[ci skip-release]' (currently: false)
[releaseNeeded]  - we are building a "pull request" (currently: false)
[releaseNeeded] Release is needed when all above is false and: 
[releaseNeeded]  - we are building on a branch that matches regex 'master|release/.+' (currently: true)
[releaseNeeded]  - and one of the following criteria is true:
[releaseNeeded]    - there are changes in the binaries when compared to previous version (currently: true)
[releaseNeeded]    - commit message contains '[ci skip-compare-publications]' (currently: false)
[releaseNeeded]    - 'skipComparePublications' property on task releaseNeeded is true (currently: false)
[releaseNeeded] 
[releaseNeeded]  Releasing because publication changed.
[releaseNeeded] :_bintrayRecordingCopy
[releaseNeeded] :bumpVersionFile
[releaseNeeded] :bumpVersionFile - updated version file 'version.properties'
[releaseNeeded]   - new version: 0.8.2
[releaseNeeded]   - previous version: 0.8.1
[releaseNeeded] :fetchContributors
[releaseNeeded]   Fetching all GitHub contributors of linkedin/play-parseq
[releaseNeeded]   Querying GitHub API for all contributors for project
[releaseNeeded] GET https://api.github.com/repos/linkedin/play-parseq/contributors?access_token=d820fc5cc70e69a8512b3ac0a25cd17b3b262491&per_page=100
[releaseNeeded] GET https://api.github.com/users/mockitoguy?access_token=d820fc5cc70e69a8512b3ac0a25cd17b3b262491
[releaseNeeded] GET https://api.github.com/users/bbarkley?access_token=d820fc5cc70e69a8512b3ac0a25cd17b3b262491
[releaseNeeded] GET https://api.github.com/users/miracle2121?access_token=d820fc5cc70e69a8512b3ac0a25cd17b3b262491
[releaseNeeded] GET https://api.github.com/users/benmccann?access_token=d820fc5cc70e69a8512b3ac0a25cd17b3b262491
[releaseNeeded] GET https://api.github.com/users/FranklinYinanDing?access_token=d820fc5cc70e69a8512b3ac0a25cd17b3b262491
[releaseNeeded] GET https://api.github.com/repos/linkedin/play-parseq/commits?access_token=d820fc5cc70e69a8512b3ac0a25cd17b3b262491&since=2018-03-25T21:09:05-0700&page=1&per_page=100
[releaseNeeded]   Serialized contributors information: build/shipkit/all-contributors.json
[releaseNeeded] :fetchReleaseNotes
[releaseNeeded] Generating release notes data for:
[releaseNeeded]   - target versions: []
[releaseNeeded]   - GitHub labels: []
[releaseNeeded]   - only pull requests: false
[releaseNeeded]   - version tag prefix: 'v'
[releaseNeeded]   Executing:
[releaseNeeded]     git fetch origin HEAD
[releaseNeeded]   Executing:
[releaseNeeded]     git log --pretty=format:%H@@info@@%ae@@info@@%an@@info@@%B%N@@commit@@ HEAD
[releaseNeeded] Retrieved 6 contribution(s) between null..HEAD
[releaseNeeded] GET https://api.github.com/repos/linkedin/play-parseq/issues?page=1&access_token=d820fc5cc70e69a8512b3ac0a25cd17b3b262491&filter=all&state=closed&labels=&direction=desc
[releaseNeeded] Retrieved 9 improvement(s) for tickets: [10, 8, 7, 6, 5, 4, 3, 2, 1]
[releaseNeeded] :updateReleaseNotes
[releaseNeeded]   Building new release notes based on /Users/sfaber/shipkit/play-parseq/docs/release-notes.md
[releaseNeeded]   Successfully updated release notes!
[releaseNeeded] :gitCommit
[releaseNeeded]   Adding files to git:
[releaseNeeded]     git add /Users/sfaber/shipkit/play-parseq/version.properties /Users/sfaber/shipkit/play-parseq/docs/release-notes.md
[releaseNeeded]   External process [add] completed.
[releaseNeeded]   Performing git commit:
[releaseNeeded]     git commit --author shipkit-org <<shipkit.org@gmail.com>> -m 0.8.1 release + release notes updated [ci skip]
[releaseNeeded] [commit] [master 79c21ff] 0.8.1 release + release notes updated [ci skip]
[releaseNeeded] [commit]  Author: shipkit-org <shipkit.org@gmail.com>
[releaseNeeded] [commit]  2 files changed, 17 insertions(+), 1 deletion(-)
[releaseNeeded] [commit]  create mode 100644 docs/release-notes.md
[releaseNeeded]   External process [commit] completed.
[releaseNeeded] :gitTag
[releaseNeeded]   Creating tag:
[releaseNeeded]     git tag -a v0.8.1 -m Created new tag v0.8.1 [ci skip]
[releaseNeeded]   External process [tag] completed.
[releaseNeeded] :gitPush
[releaseNeeded]   'git push' does not use GitHub write token because it was not specified
[releaseNeeded]   Executing:
[releaseNeeded]     git push https://github.com/linkedin/play-parseq.git v0.8.1 master --dry-run
[releaseNeeded] :bintrayUpload
[releaseNeeded] :bintrayUpload - publishing to Bintray
[releaseNeeded]   - dry run: true, version: 0.8.1, Maven Central sync: true
[releaseNeeded]   - user/org: franklinyinanding/linkedin, repository/package: test-repo/play-parseq
[releaseNeeded] :performGitPush
[releaseNeeded] :performRelease
[releaseNeeded] 
[releaseNeeded] Release shipped!
[releaseNeeded]     - Publication repository: https://bintray.com/linkedin/test-repo/play-parseq/
[releaseNeeded]     - Release notes:          https://github.com/linkedin/play-parseq/blob/master/docs/release-notes.md
[releaseNeeded] :releaseCleanUp UP-TO-DATE
[releaseNeeded] :gitTagCleanUp
[releaseNeeded]   Deleting version tag:
[releaseNeeded]     git tag -d v0.8.1
[releaseNeeded] [tag] Deleted tag 'v0.8.1' (was eb7c72c)
[releaseNeeded]   External process [tag] completed.
[releaseNeeded] :gitSoftResetCommit
[releaseNeeded]   Removing last commit:
[releaseNeeded]     git reset --soft HEAD~
[releaseNeeded]   External process [reset] completed.
[releaseNeeded] :gitStash
[releaseNeeded]   Stashing changes:
[releaseNeeded]     git stash
[releaseNeeded] [stash] Saved working directory and index state WIP on master: 80991e1 Enable release from CI
[releaseNeeded]   External process [stash] completed.
[releaseNeeded] :performGitCommitCleanUp
[releaseNeeded] 
[releaseNeeded] Deprecated Gradle features were used in this build, making it incompatible with Gradle 5.0.
[releaseNeeded] See https://docs.gradle.org/4.6/userguide/command_line_interface.html#sec:command_line_warnings
[releaseNeeded] 
[releaseNeeded] BUILD SUCCESSFUL in 7s
[releaseNeeded] 15 actionable tasks: 15 executed
  External process [releaseNeeded] completed.
  The release test was successful. Ship it!


BUILD SUCCESSFUL in 9s
1 actionable task: 1 executed
```