### PR TITLE
Enable releases to JCenter

### DIFF
--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -23,7 +23,7 @@ plugins.withId("org.shipkit.bintray") {
        }
 
        pkg {
-           repo = 'test-repo' //TODO: change to 'maven'
+           repo = 'maven'
            userOrg = 'linkedin'
            name = 'play-parseq'
            licenses = ['Apache-2.0']


### PR DESCRIPTION
This is a first step to releasing to Maven Central.

Merging this PR will produce a version to a very visible public repository (JCenter), and we should never delete those artifacts once they are published.