### PR TITLE
2.4.x context fix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val playParSeqVersion = "0.6.0"
+val playParSeqVersion = "0.6.1"
 
 val playParSeqScalaVersion = "2.11.11"
 

--- a/src/core/java/app/com/linkedin/playparseq/j/PlayParSeqImpl.java
+++ b/src/core/java/app/com/linkedin/playparseq/j/PlayParSeqImpl.java
@@ -88,7 +88,7 @@ public class PlayParSeqImpl extends PlayParSeqHelper implements PlayParSeq {
   public <T> F.Promise<T> runTask(final Http.Context context, final Task<T> task) {
     Promise<T> scalaPromise = FPromiseHelper.empty();
     // Wrap a Scala Future which binds to the ParSeq Task
-    Task<T> wrappedTask = bindTaskToFuture(task, scalaPromise);
+    Task<T> wrappedTask = bindTaskToPromise(task, scalaPromise);
     // Put the ParSeq Task into store
     _parSeqTaskStore.put(context, wrappedTask);
     // Run the ParSeq Task

--- a/src/core/java/app/com/linkedin/playparseq/j/PlayParSeqImpl.java
+++ b/src/core/java/app/com/linkedin/playparseq/j/PlayParSeqImpl.java
@@ -18,10 +18,13 @@ import com.linkedin.playparseq.utils.PlayParSeqHelper;
 import java.util.concurrent.Callable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+
+import play.core.j.FPromiseHelper;
 import play.libs.F;
 import play.mvc.Http;
 import scala.concurrent.Future;
 import scala.concurrent.Future$;
+import scala.concurrent.Promise;
 import scala.runtime.AbstractFunction0;
 
 
@@ -83,14 +86,15 @@ public class PlayParSeqImpl extends PlayParSeqHelper implements PlayParSeq {
 
   @Override
   public <T> F.Promise<T> runTask(final Http.Context context, final Task<T> task) {
+    Promise<T> scalaPromise = FPromiseHelper.empty();
     // Wrap a Scala Future which binds to the ParSeq Task
-    F.Promise<T> promise = F.Promise.wrap(bindTaskToFuture(task));
+    Task<T> wrappedTask = bindTaskToFuture(task, scalaPromise);
     // Put the ParSeq Task into store
-    _parSeqTaskStore.put(context, task);
+    _parSeqTaskStore.put(context, wrappedTask);
     // Run the ParSeq Task
-    _engine.run(task);
+    _engine.run(wrappedTask);
     // Return the Play Promise
-    return promise;
+    return F.Promise.wrap(scalaPromise.future());
   }
 
   @Override

--- a/src/core/scala/app/com/linkedin/playparseq/s/PlayParSeq.scala
+++ b/src/core/scala/app/com/linkedin/playparseq/s/PlayParSeq.scala
@@ -89,7 +89,7 @@ class PlayParSeqImpl @Inject()(engine: Engine, parSeqTaskStore: ParSeqTaskStore)
   override def runTask[T](task: Task[T])(implicit requestHeader: RequestHeader): Future[T] = {
     val scalaPromise: Promise[T] = Promise[T]()
     // Bind a Future to the ParSeq Task
-    val boundTask: Task[T] = bindTaskToFuture(task, scalaPromise)
+    val boundTask: Task[T] = bindTaskToPromise(task, scalaPromise)
     // Put the ParSeq Task into store
     parSeqTaskStore.put(boundTask)
     // Run the ParSeq Task

--- a/src/core/scala/app/com/linkedin/playparseq/s/PlayParSeq.scala
+++ b/src/core/scala/app/com/linkedin/playparseq/s/PlayParSeq.scala
@@ -16,7 +16,9 @@ import com.linkedin.playparseq.s.stores.ParSeqTaskStore
 import com.linkedin.playparseq.utils.PlayParSeqHelper
 import javax.inject.{Inject, Singleton}
 import play.api.mvc.RequestHeader
+
 import scala.concurrent.Future
+import scala.concurrent.Promise
 
 
 /**
@@ -85,13 +87,14 @@ class PlayParSeqImpl @Inject()(engine: Engine, parSeqTaskStore: ParSeqTaskStore)
   }
 
   override def runTask[T](task: Task[T])(implicit requestHeader: RequestHeader): Future[T] = {
+    val scalaPromise: Promise[T] = Promise[T]()
     // Bind a Future to the ParSeq Task
-    val future: Future[T] = bindTaskToFuture(task)
+    val boundTask: Task[T] = bindTaskToFuture(task, scalaPromise)
     // Put the ParSeq Task into store
-    parSeqTaskStore.put(task)
+    parSeqTaskStore.put(boundTask)
     // Run the ParSeq Task
-    engine.run(task)
+    engine.run(boundTask)
     // Return the Future
-    future
+    scalaPromise.future
   }
 }

--- a/src/trace/scala/app/com/linkedin/playparseq/trace/controllers/ParSeqTraceViewer.scala
+++ b/src/trace/scala/app/com/linkedin/playparseq/trace/controllers/ParSeqTraceViewer.scala
@@ -16,6 +16,7 @@ import com.linkedin.playparseq.s.PlayParSeqImplicits._
 import com.linkedin.playparseq.utils.PlayParSeqHelper
 import java.io.ByteArrayInputStream
 import java.nio.file.{Files, Path}
+
 import javax.inject.{Inject, Singleton}
 import javax.servlet.http.HttpServletResponse
 import org.apache.commons.io.FileUtils
@@ -24,7 +25,9 @@ import play.api.Logger
 import play.api.inject.ApplicationLifecycle
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.mvc.{Action, AnyContent, Controller, Result}
+
 import scala.concurrent.Future
+import scala.concurrent.Promise
 import scala.sys.process
 
 
@@ -104,9 +107,9 @@ class ParSeqTraceViewer @Inject()(engine: Engine, applicationLifecycle: Applicat
       }
     })
     // Run task
-    val result = bindTaskToFuture(task)
-    engine.run(task)
-    result
+    val promise: Promise[Result] = Promise()
+    engine.run(bindTaskToFuture(task, promise))
+    promise.future
   })
 
   /**
@@ -123,7 +126,7 @@ class ParSeqTraceViewer @Inject()(engine: Engine, applicationLifecycle: Applicat
           case _ => ""
         }
       } catch {
-        case e: Exception => 
+        case e: Exception =>
           val ret = "No executable for dot found. See http://www.graphviz.org"
           Log.error(ret)
           ret

--- a/src/trace/scala/app/com/linkedin/playparseq/trace/controllers/ParSeqTraceViewer.scala
+++ b/src/trace/scala/app/com/linkedin/playparseq/trace/controllers/ParSeqTraceViewer.scala
@@ -108,7 +108,7 @@ class ParSeqTraceViewer @Inject()(engine: Engine, applicationLifecycle: Applicat
     })
     // Run task
     val promise: Promise[Result] = Promise()
-    engine.run(bindTaskToFuture(task, promise))
+    engine.run(bindTaskToPromise(task, promise))
     promise.future
   })
 

--- a/src/trace/scala/app/com/linkedin/playparseq/trace/s/ParSeqTraceBuilder.scala
+++ b/src/trace/scala/app/com/linkedin/playparseq/trace/s/ParSeqTraceBuilder.scala
@@ -11,6 +11,8 @@
  */
 package com.linkedin.playparseq.trace.s
 
+import com.linkedin.parseq.Task
+import com.linkedin.parseq.promise.PromiseListener
 import com.linkedin.playparseq.s.stores.{ContextRequest, ParSeqTaskStore}
 import com.linkedin.playparseq.trace.s.renderers.ParSeqTraceRenderer
 import com.linkedin.playparseq.trace.s.sensors.ParSeqTraceSensor
@@ -18,8 +20,10 @@ import com.linkedin.playparseq.trace.utils.ParSeqTraceHelper
 import javax.inject.Inject
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.mvc._
+
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.Future
+import scala.concurrent.Promise
 
 
 /**


### PR DESCRIPTION
When using a PromiseListener the call completion is not fired on the thread executing the Task. This causes an issue when ThreadLocals (such as MDC) are propagated between Play and ParSeq threads