### PR TITLE
Remove methods which don't take HttpExecutionContext

### DIFF
--- a/sample/app/controllers/j/CoreOnlySample.java
+++ b/sample/app/controllers/j/CoreOnlySample.java
@@ -15,6 +15,7 @@ import com.linkedin.playparseq.j.PlayParSeq;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
+import play.libs.concurrent.HttpExecutionContext;
 import play.mvc.Controller;
 import play.mvc.Http;
 import play.mvc.Result;
@@ -36,6 +37,11 @@ public class CoreOnlySample extends Controller {
   private final PlayParSeq _playParSeq;
 
   /**
+   * The field _httpExecutionContext is injected execution context for managing thread local states
+   */
+  private final HttpExecutionContext _httpExecutionContext;
+
+  /**
    * The field DEFAULT_FAILURE is the default failure output.
    */
   public final static String DEFAULT_FAILURE = "Start Index Error";
@@ -46,8 +52,9 @@ public class CoreOnlySample extends Controller {
    * @param playParSeq The injected {@link PlayParSeq} component
    */
   @Inject
-  public CoreOnlySample(final PlayParSeq playParSeq) {
+  public CoreOnlySample(final PlayParSeq playParSeq, HttpExecutionContext httpExecutionContext) {
     _playParSeq = playParSeq;
+    _httpExecutionContext = httpExecutionContext;
   }
 
   /**
@@ -76,7 +83,7 @@ public class CoreOnlySample extends Controller {
         // Convert to ParSeq Task
         _playParSeq.toTask("substring", () -> CompletableFuture.supplyAsync(() -> text.substring(start))
             // Recover
-            .exceptionally(__ -> DEFAULT_FAILURE)).map("getResult", Results::ok));
+            .exceptionally(__ -> DEFAULT_FAILURE), null).map("getResult", Results::ok));
   }
 
 }

--- a/sample/app/controllers/j/SingleTaskSample.java
+++ b/sample/app/controllers/j/SingleTaskSample.java
@@ -17,6 +17,7 @@ import com.linkedin.playparseq.trace.j.ParSeqTraceAction;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
+import play.libs.concurrent.HttpExecutionContext;
 import play.mvc.Controller;
 import play.mvc.Http;
 import play.mvc.Result;
@@ -37,13 +38,19 @@ public class SingleTaskSample extends Controller {
   private final PlayParSeq _playParSeq;
 
   /**
+   * The field _httpExecutionContext is injected execution context for managing thread local states
+   */
+  private final HttpExecutionContext _httpExecutionContext;
+
+  /**
    * The constructor injects the {@link PlayParSeq}.
    *
    * @param playParSeq The injected {@link PlayParSeq} component
    */
   @Inject
-  public SingleTaskSample(final PlayParSeq playParSeq) {
+  public SingleTaskSample(final PlayParSeq playParSeq, final HttpExecutionContext httpExecutionContext) {
     _playParSeq = playParSeq;
+    _httpExecutionContext = httpExecutionContext;
   }
 
   /**
@@ -60,7 +67,7 @@ public class SingleTaskSample extends Controller {
         // In parallel
         Task.par(
             // Convert to ParSeq Task
-            _playParSeq.toTask("hello", () -> CompletableFuture.supplyAsync(() -> "Hello")),
+            _playParSeq.toTask("hello", () -> CompletableFuture.supplyAsync(() -> "Hello"), _httpExecutionContext),
             // Simple ParSeq Task
             Task.value("world", "World")).map((h, w) -> ok(h + " " + w)));
   }

--- a/src/core/java/app/com/linkedin/playparseq/j/PlayParSeq.java
+++ b/src/core/java/app/com/linkedin/playparseq/j/PlayParSeq.java
@@ -33,32 +33,12 @@ public interface PlayParSeq {
    * The method toTask converts a {@code Callable<CompletionStage<T>>} to a ParSeq {@code Task<T>}.
    *
    * @param name The String which describes the Task and shows up in a trace
-   * @param f The Callable which returns a CompletionStage
-   * @param <T> The type parameter of the CompletionStage and the ParSeq Task
-   * @return The ParSeq Task
-   */
-  <T> Task<T> toTask(final String name, final Callable<CompletionStage<T>> f);
-
-  /**
-   * The method toTask converts a {@code Callable<CompletionStage<T>>} to a ParSeq {@code Task<T>}.
-   *
-   * @param name The String which describes the Task and shows up in a trace
    * @param executionContext The Executor of the async CompletionStage
    * @param f The Callable which returns a CompletionStage
    * @param <T> The type parameter of the CompletionStage and the ParSeq Task
    * @return The ParSeq Task
    */
   <T> Task<T> toTask(final String name, final Callable<CompletionStage<T>> f, final HttpExecutionContext executionContext);
-
-  /**
-   * The method toTask converts a {@code Callable<CompletionStage<T>>} to a ParSeq {@code Task<T>}, which binds with a
-   * default name.
-   *
-   * @param f The Callable which returns a CompletionStage
-   * @param <T> The type parameter of the CompletionStage and the ParSeq Task
-   * @return The ParSeq Task
-   */
-  <T> Task<T> toTask(final Callable<CompletionStage<T>> f);
 
   /**
    * The method toTask converts a {@code Callable<CompletionStage<T>>} to a ParSeq {@code Task<T>}, which binds with a

--- a/src/core/java/app/com/linkedin/playparseq/j/PlayParSeqImpl.java
+++ b/src/core/java/app/com/linkedin/playparseq/j/PlayParSeqImpl.java
@@ -67,25 +67,9 @@ public class PlayParSeqImpl extends PlayParSeqHelper implements PlayParSeq {
    * {@inheritDoc}
    */
   @Override
-  public <T> Task<T> toTask(final String name, final Callable<CompletionStage<T>> f) {
-    return toTask(name, f, null);
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
   public <T> Task<T> toTask(final String name, final Callable<CompletionStage<T>> f, final HttpExecutionContext executionContext) {
     // Bind a Task to the CompletionStage for both success and failure
     return Task.async(name, transferCompletionStageCallableToPromiseCallable(f, executionContext));
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public <T> Task<T> toTask(final Callable<CompletionStage<T>> f) {
-    return toTask(DEFAULT_TASK_NAME, f);
   }
 
   /**


### PR DESCRIPTION
It's unsafe to use those as context might be lost during switch of threads
Updated the samples for the same